### PR TITLE
add -loader suffix to all webpack loaders 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,10 +39,10 @@ const config = server => ({
       {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
-        loader: 'babel'
+        loader: 'babel-loader'
       },
-      { test: /\.css$/, loader: extractTextPlugin.extract(['css']) },
-      { test: /\.(gif|png|jpg)$/, loader: 'file' }
+      { test: /\.css$/, loader: extractTextPlugin.extract(['css-loader']) },
+      { test: /\.(gif|png|jpg)$/, loader: 'file-loader' }
     ]
   },
 


### PR DESCRIPTION
prevents webpack errors on npm start